### PR TITLE
Fix host port

### DIFF
--- a/pkg/api/k8s/k8s.go
+++ b/pkg/api/k8s/k8s.go
@@ -97,16 +97,18 @@ func GetPodFullName(podName, namespace string) string {
 var flagHostnameOverride = flag.String("hostname-override", "", "kubelet hostname override, if set, galaxy use this"+
 	" as node name to get node from apiserver")
 
-// copied from kubelet
-// GetHostname returns OS's hostname if 'hostnameOverride' is empty; otherwise, return 'hostnameOverride'.
+// GetHostname returns OS's hostname if 'hostnameOverride' is empty and environment 'MY_NODE_NAME'; otherwise, return 'hostnameOverride'.
 func GetHostname() string {
 	hostname := *flagHostnameOverride
 	if hostname == "" {
-		nodename, err := os.Hostname()
-		if err != nil {
-			glog.Fatalf("Couldn't determine hostname: %v", err)
+		hostname = os.Getenv("MY_NODE_NAME")
+		if hostname == "" {
+			nodename, err := os.Hostname()
+			if err != nil {
+				glog.Fatalf("Couldn't determine hostname: %v", err)
+			}
+			hostname = nodename
 		}
-		hostname = nodename
 	}
 	return strings.ToLower(strings.TrimSpace(hostname))
 }

--- a/pkg/galaxy/server.go
+++ b/pkg/galaxy/server.go
@@ -170,7 +170,7 @@ func parsePorts(pod *corev1.Pod, portMappingOn bool) []k8s.Port {
 					ContainerPort: port.ContainerPort,
 					Protocol:      string(port.Protocol),
 					PodName:       pod.Name,
-					HostIP:        pod.Status.HostIP,
+					HostIP:        port.HostIP,
 					PodIP:         pod.Status.PodIP,
 				}
 				ports = append(ports, tmp)

--- a/pkg/galaxy/server.go
+++ b/pkg/galaxy/server.go
@@ -160,7 +160,8 @@ func (g *Galaxy) requestFunc(req *galaxyapi.PodRequest) (data []byte, err error)
 	return
 }
 
-func parsePorts(pod *corev1.Pod, portMappingOn bool) []k8s.Port {
+func parsePorts(pod *corev1.Pod) []k8s.Port {
+	_, portMappingOn := pod.Annotations[k8s.PortMappingPortsAnnotation]
 	var ports []k8s.Port
 	for _, container := range pod.Spec.Containers {
 		for _, port := range container.Ports {
@@ -293,14 +294,15 @@ func (g *Galaxy) setupIPtables() error {
 		if pod.Status.Phase != corev1.PodRunning {
 			continue
 		}
-		if pod.Annotations == nil || pod.Annotations[k8s.PortMappingPortsAnnotation] == "" {
-			continue
-		}
 		var ports []k8s.Port
-		if err := json.Unmarshal([]byte(pod.Annotations[k8s.PortMappingPortsAnnotation]), &ports); err != nil {
-			glog.Warningf("failed to unmarshal %s_%s annotation %s: %v", pod.Name, pod.Namespace,
-				k8s.PortMappingPortsAnnotation, err)
-			continue
+		if pod.Annotations != nil && pod.Annotations[k8s.PortMappingPortsAnnotation] != "" {
+			if err := json.Unmarshal([]byte(pod.Annotations[k8s.PortMappingPortsAnnotation]), &ports); err != nil {
+				glog.Warningf("failed to unmarshal %s_%s annotation %s: %v", pod.Name, pod.Namespace,
+					k8s.PortMappingPortsAnnotation, err)
+				continue
+			}
+		} else {
+			ports = parsePorts(pod)
 		}
 		// open ports on start
 		if err := g.pmhandler.OpenHostports(k8s.GetPodFullName(pod.Name, pod.Namespace), false, ports); err != nil {
@@ -327,7 +329,7 @@ func (g *Galaxy) setupIPtables() error {
 func (g *Galaxy) setupPortMapping(req *galaxyapi.PodRequest, containerID string, result *t020.Result,
 	pod *corev1.Pod) error {
 	_, portMappingOn := pod.Annotations[k8s.PortMappingPortsAnnotation]
-	req.Ports = parsePorts(pod, portMappingOn)
+	req.Ports = parsePorts(pod)
 	if len(req.Ports) == 0 {
 		return nil
 	}

--- a/yaml/galaxy.yaml
+++ b/yaml/galaxy.yaml
@@ -81,6 +81,11 @@ spec:
       # private-cloud should run without --route-eni
       # args: ["-c", "cp -p /etc/galaxy/cni/00-galaxy.conf /etc/cni/net.d/; cp -p /opt/cni/galaxy/bin/galaxy-sdn /opt/cni/galaxy/bin/loopback /opt/cni/bin/; /usr/bin/galaxy --logtostderr=true --v=3"]
         imagePullPolicy: Always
+        env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         name: galaxy
         resources:
           requests:


### PR DESCRIPTION
- Getting hostIP from `containerPort.HostIP` instead of from `pod.status.HostIP`.
- If galaxy start or restart, it syncs all containerPorts by listing all pods on current node with `spec.nodeName=$hostName`. This PR fix getting invalid hostName within galaxy pod.
