### PR TITLE
fix: Only ask users to enable experimental features when necessary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,4 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
-          make image
+          make manifest

--- a/build/lib/build.sh
+++ b/build/lib/build.sh
@@ -16,6 +16,10 @@
 # WARRANTIES OF ANY KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations under the License.
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 PKG=${PKG:-"tkestack.io/galaxy"}
 GOBUILD_FLAGS=${debug:+"-v"}
 GO_LDFLAGS=${GO_LDFLAGS:-""}

--- a/build/lib/create-manifest.sh
+++ b/build/lib/create-manifest.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 REGISTRY_PREFIX=${REGISTRY_PREFIX:-"tkestack"}
 PLATFORMS=${PLATFORMS:-"linux_amd64 linux_arm64"}
 

--- a/build/lib/golang.mk
+++ b/build/lib/golang.mk
@@ -32,7 +32,7 @@ _DOCKER_RUN_EXTRA_ARGS += --env HTTP_PROXY=${HTTP_PROXY}
 endif
 ifdef HTTPS_PROXY
 _DOCKER_RUN_EXTRA_ARGS += --env HTTPS_PROXY=${HTTPS_PROXY}
-else
+else ifdef HTTP_PROXY
 _DOCKER_RUN_EXTRA_ARGS += --env HTTPS_PROXY=${HTTP_PROXY}
 endif
 
@@ -96,7 +96,7 @@ go.docker.build.%: image.daemon.verify
 	-v $(ROOT_DIR):/go/src/$(ROOT_PACKAGE) \
 	-v $(GOPATH)/pkg:/go/pkg -w /go/src/$(ROOT_PACKAGE) \
 	$(GO_IMAGE) /bin/sh -c 'PLATFORM=$* VERSION=$(VERSION) BINS="$(BINS)" make build'
-	@## Docker has a bug here. So client may remove image first and tag image
+	@## Docker has a bug here. So client may remove image first
 	@$(DOCKER) tag $(GO_IMAGE) $(GO_IMAGE)-$*
 	@$(DOCKER) rmi $(GO_IMAGE)
 


### PR DESCRIPTION
1. Only ask users to enable Docker experimental features when necessary
2. Change `release` workflow to call `make manifest`. That is, push manifest lists to docker hub when trigger `release` workflow