### PR TITLE
fix: Check Docker API version instead of Docker version

### DIFF
--- a/build/lib/create-manifest.sh
+++ b/build/lib/create-manifest.sh
@@ -1,4 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Tencent is pleased to support the open source community by making TKEStack
+# available.
+#
+# Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at
+#
+# https://opensource.org/licenses/Apache-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
 
 set -o errexit
 set -o nounset

--- a/build/lib/image.mk
+++ b/build/lib/image.mk
@@ -18,7 +18,7 @@
 # Makefile helper functions for docker image
 
 DOCKER := docker
-DOCKER_SUPPORTED_VERSIONS ?= 18|19
+DOCKER_SUPPORTED_API_VERSION ?= 1.32
 
 REGISTRY_PREFIX ?= tkestack
 BASE_IMAGE = centos:7
@@ -41,9 +41,11 @@ endif
 
 .PHONY: image.verify
 image.verify:
-	$(eval PASS := $(shell $(DOCKER) -v | grep -q -E '\bversion ($(DOCKER_SUPPORTED_VERSIONS))\b' && echo 0 || echo 1))
-	@if [ $(PASS) -ne 0 ]; then \
-		echo "Unsupported docker version. Please make install one of the following supported version: '$(DOCKER_SUPPORTED_VERSIONS)'"; \
+	$(eval API_VERSION := $(shell $(DOCKER) version | grep -E 'API version: {6}[0-9]' | awk '{print $$3} END { if (NR==0) print 0}' ))
+	$(eval GREATER := $(shell echo "$(API_VERSION) > $(DOCKER_SUPPORTED_API_VERSION)" | bc))
+	@if [ $(GREATER) -ne 1 ]; then \
+		$(DOCKER) -v ;\
+		echo "Unsupported docker version. Docker API version should be greater than $(DOCKER_SUPPORTED_API_VERSION)"; \
 		exit 1; \
 	fi
 


### PR DESCRIPTION
This PR can pass the `build` and `release` actions, and update both `tkestack/galaxy-amd64` and `tkestack/galaxy` by using manifest:

![屏幕快照 2020-03-03 14 07 07](https://user-images.githubusercontent.com/26450747/75747619-628af300-5d58-11ea-9aff-b841d0f16161.png)

![屏幕快照 2020-03-03 14 10 02](https://user-images.githubusercontent.com/26450747/75747941-39b72d80-5d59-11ea-8807-2437c9ca75b1.png)

![屏幕快照 2020-03-03 14 11 57](https://user-images.githubusercontent.com/26450747/75747965-463b8600-5d59-11ea-9d7e-efe6a0853159.png)
