### PR TITLE
Fix invalid docker socket path if docker restarts

### DIFF
--- a/pkg/api/docker/docker.go
+++ b/pkg/api/docker/docker.go
@@ -29,7 +29,6 @@ import (
 var (
 	// defaultTimeout is the default timeout of short running docker operations.
 	defaultTimeout = 2 * time.Minute
-	unixSocket     = "unix:///var/run/docker.sock"
 )
 
 type DockerInterface struct {
@@ -39,7 +38,7 @@ type DockerInterface struct {
 
 // NewDockerInterface creates an DockerInterface
 func NewDockerInterface() (*DockerInterface, error) {
-	dockerCli, err := getDockerClient(unixSocket)
+	dockerCli, err := getDockerClient("")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/galaxy/server.go
+++ b/pkg/galaxy/server.go
@@ -292,7 +292,7 @@ func (g *Galaxy) setupIPtables() error {
 	var allPorts []k8s.Port
 	for i := range pods.Items {
 		pod := &pods.Items[i]
-		if pod.Status.Phase != corev1.PodRunning {
+		if pod.Status.Phase != corev1.PodRunning || pod.Spec.HostNetwork {
 			continue
 		}
 		var ports []k8s.Port

--- a/yaml/galaxy.yaml
+++ b/yaml/galaxy.yaml
@@ -90,6 +90,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: DOCKER_HOST
+            value: unix:///host/run/docker.sock
         name: galaxy
         resources:
           requests:
@@ -115,7 +117,7 @@ spec:
         - name: cni-state
           mountPath: /var/lib/cni
         - name: docker-sock
-          mountPath: /run/docker.sock
+          mountPath: /host/run/
       terminationGracePeriodSeconds: 30
       volumes:
       - name: galaxy-run
@@ -146,9 +148,10 @@ spec:
           defaultMode: 420
           name: cni-etc
         name: cni-etc
-      - name: docker-sock
-        hostPath:
-          path: /run/docker.sock
+       - name: docker-sock
+         # in case of docker restart, /run/docker.sock may change, we have to mount the /run directory
+         hostPath:
+           path: /run/
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
and skip setting up hostport for host network pod when starting galaxy.

Fixes https://github.com/tkestack/galaxy/issues/38