### PR TITLE
fix iptables -s lack of podIP which causes galaxy crash

### DIFF
--- a/pkg/galaxy/server.go
+++ b/pkg/galaxy/server.go
@@ -292,7 +292,7 @@ func (g *Galaxy) setupIPtables() error {
 	var allPorts []k8s.Port
 	for i := range pods.Items {
 		pod := &pods.Items[i]
-		if pod.Status.Phase != corev1.PodRunning || pod.Spec.HostNetwork {
+		if len(pod.Status.PodIP) == 0 || pod.Spec.HostNetwork {
 			continue
 		}
 		var ports []k8s.Port


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/core/v1/types.go#L2431
Restarting pod will be set as Running too.
More details https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet_pods.go#L1323-L1328