### PR TITLE
Release ip fully concurrently

### DIFF
--- a/pkg/ipam/schedulerplugin/floatingip_plugin.go
+++ b/pkg/ipam/schedulerplugin/floatingip_plugin.go
@@ -112,9 +112,7 @@ func (p *FloatingIPPlugin) Run(stop chan struct{}) {
 		}
 		p.syncPodIPsIntoDB()
 	}, time.Duration(p.conf.ResyncInterval)*time.Minute, stop)
-	for i := 0; i < 5; i++ {
-		go p.loop(stop)
-	}
+	go p.loop(stop)
 }
 
 // updateConfigMap fetches the newest floatingips configmap and syncs in memory/db config,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/985861/91131917-a0e9e500-e6df-11ea-9b58-5b3217e4225a.png)
The num of release ip goroutine is the bottleneck when scaling down and scaling up multiple pods. From the above pic, it may take 20 seconds to get ip released once receive pod delete event. Please note this may happen only with cloud provider.