### PR TITLE
Resync ip if pod uid changed

### DIFF
--- a/pkg/ipam/api/api.go
+++ b/pkg/ipam/api/api.go
@@ -60,7 +60,6 @@ type FloatingIP struct {
 	UpdateTime time.Time         `json:"updateTime,omitempty"`
 	Status     string            `json:"status,omitempty"`
 	Releasable bool              `json:"releasable,omitempty"`
-	attr       string            `json:"-"`
 	labels     map[string]string `json:"-"`
 }
 
@@ -349,8 +348,7 @@ func transform(fips []floatingip.FloatingIP) []FloatingIP {
 			AppType:    toAppType(keyObj.AppTypePrefix),
 			Policy:     fips[i].Policy,
 			UpdateTime: fips[i].UpdatedAt,
-			labels:     fips[i].Labels,
-			attr:       fips[i].Attr})
+			labels:     fips[i].Labels})
 	}
 	return res
 }

--- a/pkg/ipam/api/pool.go
+++ b/pkg/ipam/api/pool.go
@@ -164,7 +164,7 @@ func (c *PoolController) preAllocateIP(req *restful.Request, resp *restful.Respo
 	}
 	needAllocateIPs := pool.Size - len(fips)
 	for i := 0; i < needAllocateIPs; i++ {
-		ip, err := c.IPAM.AllocateInSubnet(poolPrefix, subnetIPNet, constant.ReleasePolicyNever, "")
+		ip, err := c.IPAM.AllocateInSubnet(poolPrefix, subnetIPNet, floatingip.Attr{Policy: constant.ReleasePolicyNever})
 		if err == nil {
 			glog.Infof("allocated ip %s to %s during creating or updating pool", ip.String(), poolPrefix)
 			continue

--- a/pkg/ipam/floatingip/ipam.go
+++ b/pkg/ipam/floatingip/ipam.go
@@ -44,8 +44,9 @@ type IPAM interface {
 	AllocateInSubnet(string, *net.IPNet, Attr) (net.IP, error)
 	// AllocateInSubnetWithKey allocate a floatingIP in given subnet and key.
 	AllocateInSubnetWithKey(oldK, newK, subnet string, attr Attr) error
-	// ReserveIP can reserve a IP entitled by a terminated pod. Attributes expect policy attr will be updated.
-	ReserveIP(oldK, newK string, attr Attr) error
+	// ReserveIP can reserve a IP entitled by a terminated pod. Attributes **expect policy attr** will be updated.
+	// Returns true if key or attr updated.
+	ReserveIP(oldK, newK string, attr Attr) (bool, error)
 	// UpdateAttr update floatingIP's release policy and attrs according to ip and key
 	UpdateAttr(string, net.IP, Attr) error
 	// Release release a given IP.

--- a/pkg/ipam/floatingip/ipam.go
+++ b/pkg/ipam/floatingip/ipam.go
@@ -39,15 +39,15 @@ type IPAM interface {
 	// unreleased map stores ip with its latest key if key changed
 	ReleaseIPs(map[string]string) (map[string]string, map[string]string, error)
 	// AllocateSpecificIP allocate pod a specific IP.
-	AllocateSpecificIP(string, net.IP, constant.ReleasePolicy, string) error
+	AllocateSpecificIP(string, net.IP, Attr) error
 	// AllocateInSubnet allocate subnet of IPs.
-	AllocateInSubnet(string, *net.IPNet, constant.ReleasePolicy, string) (net.IP, error)
+	AllocateInSubnet(string, *net.IPNet, Attr) (net.IP, error)
 	// AllocateInSubnetWithKey allocate a floatingIP in given subnet and key.
-	AllocateInSubnetWithKey(oldK, newK, subnet string, policy constant.ReleasePolicy, attr string) error
-	// ReserveIP can reserve a IP entitled by a terminated pod.
-	ReserveIP(oldK, newK, attr string) error
-	// UpdatePolicy update floatingIP's release policy and attr according to ip and key
-	UpdatePolicy(string, net.IP, constant.ReleasePolicy, string) error
+	AllocateInSubnetWithKey(oldK, newK, subnet string, attr Attr) error
+	// ReserveIP can reserve a IP entitled by a terminated pod. Attributes expect policy attr will be updated.
+	ReserveIP(oldK, newK string, attr Attr) error
+	// UpdateAttr update floatingIP's release policy and attrs according to ip and key
+	UpdateAttr(string, net.IP, Attr) error
 	// Release release a given IP.
 	Release(string, net.IP) error
 	// First returns the first matched IP by key.

--- a/pkg/ipam/floatingip/store_crd_test.go
+++ b/pkg/ipam/floatingip/store_crd_test.go
@@ -38,13 +38,14 @@ func TestAddFloatingIPEventByUser(t *testing.T) {
 		IP:        net.ParseIP("10.49.27.205"),
 		Key:       "pod2",
 		Subnets:   sets.NewString("subnet1"),
-		Attr:      "pod2 attr",
 		Policy:    0,
 		UpdatedAt: time.Now(),
 	}
 	fipCrd := ipam.newFIPCrd(fip.IP.String())
 	fipCrd.Labels[constant.ReserveFIPLabel] = ""
-	assign(fipCrd, fip)
+	if err := assign(fipCrd, fip); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := ipam.client.GalaxyV1alpha1().FloatingIPs().Create(fipCrd); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ipam/schedulerplugin/cloudprovider_test.go
+++ b/pkg/ipam/schedulerplugin/cloudprovider_test.go
@@ -24,6 +24,7 @@ import (
 
 	"tkestack.io/galaxy/pkg/api/galaxy/constant"
 	"tkestack.io/galaxy/pkg/api/k8s/schedulerapi"
+	"tkestack.io/galaxy/pkg/ipam/floatingip"
 	. "tkestack.io/galaxy/pkg/ipam/schedulerplugin/testing"
 	schedulerplugin_util "tkestack.io/galaxy/pkg/ipam/schedulerplugin/util"
 )
@@ -36,7 +37,8 @@ func TestConcurrentBindUnbind(t *testing.T) {
 	defer func() { stopChan <- struct{}{} }()
 	cloudProvider := &fakeCloudProvider1{m: make(map[string]string)}
 	plugin.cloudProvider = cloudProvider
-	if err := plugin.ipam.AllocateSpecificIP(podKey.KeyInDB, net.ParseIP("10.49.27.216"), constant.ReleasePolicyPodDelete, "{}"); err != nil {
+	if err := plugin.ipam.AllocateSpecificIP(podKey.KeyInDB, net.ParseIP("10.49.27.216"),
+		floatingip.Attr{Policy: constant.ReleasePolicyPodDelete}); err != nil {
 		t.Fatal(err)
 	}
 	var wg sync.WaitGroup

--- a/pkg/ipam/schedulerplugin/ipam.go
+++ b/pkg/ipam/schedulerplugin/ipam.go
@@ -136,10 +136,13 @@ func (p *FloatingIPPlugin) releaseIP(key string, reason string) error {
 }
 
 func (p *FloatingIPPlugin) reserveIP(key, prefixKey string, reason string) error {
-	if err := p.ipam.ReserveIP(key, prefixKey, floatingip.Attr{}); err != nil {
+	if reserved, err := p.ipam.ReserveIP(key, prefixKey, floatingip.Attr{}); err != nil {
 		return fmt.Errorf("reserve ip from pod %s to %s: %v", key, prefixKey, err)
+	} else if reserved {
+		// resync will call reserveIP for sts and tapp pod with immutable/never release policy for endless times,
+		// so print "success reserved ip" only when succeeded
+		glog.Infof("reserved ip from pod %s to %s, because %s", key, prefixKey, reason)
 	}
-	glog.Infof("reserved ip from pod %s to %s, because %s", key, prefixKey, reason)
 	return nil
 }
 

--- a/pkg/ipam/schedulerplugin/ipam.go
+++ b/pkg/ipam/schedulerplugin/ipam.go
@@ -48,9 +48,8 @@ func (p *FloatingIPPlugin) ensureIPAMConf(lastConf *string, newConf string) (boo
 	return true, nil
 }
 
-func (p *FloatingIPPlugin) allocateInSubnet(key string, subnet *net.IPNet, policy constant.ReleasePolicy, attr,
-	when string) error {
-	ip, err := p.ipam.AllocateInSubnet(key, subnet, policy, attr)
+func (p *FloatingIPPlugin) allocateInSubnet(key string, subnet *net.IPNet, attr floatingip.Attr, when string) error {
+	ip, err := p.ipam.AllocateInSubnet(key, subnet, attr)
 	if err != nil {
 		return err
 	}
@@ -58,9 +57,8 @@ func (p *FloatingIPPlugin) allocateInSubnet(key string, subnet *net.IPNet, polic
 	return nil
 }
 
-func (p *FloatingIPPlugin) allocateInSubnetWithKey(oldK, newK, subnet string, policy constant.ReleasePolicy,
-	attr, when string) error {
-	if err := p.ipam.AllocateInSubnetWithKey(oldK, newK, subnet, policy, attr); err != nil {
+func (p *FloatingIPPlugin) allocateInSubnetWithKey(oldK, newK, subnet string, attr floatingip.Attr, when string) error {
+	if err := p.ipam.AllocateInSubnetWithKey(oldK, newK, subnet, attr); err != nil {
 		return err
 	}
 	fip, err := p.ipam.First(newK)
@@ -138,7 +136,7 @@ func (p *FloatingIPPlugin) releaseIP(key string, reason string) error {
 }
 
 func (p *FloatingIPPlugin) reserveIP(key, prefixKey string, reason string) error {
-	if err := p.ipam.ReserveIP(key, prefixKey, getAttr("", "")); err != nil {
+	if err := p.ipam.ReserveIP(key, prefixKey, floatingip.Attr{}); err != nil {
 		return fmt.Errorf("reserve ip from pod %s to %s: %v", key, prefixKey, err)
 	}
 	glog.Infof("reserved ip from pod %s to %s, because %s", key, prefixKey, reason)

--- a/pkg/ipam/schedulerplugin/resync.go
+++ b/pkg/ipam/schedulerplugin/resync.go
@@ -17,13 +17,11 @@
 package schedulerplugin
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 	"strconv"
 	"strings"
 
-	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metaErrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +31,6 @@ import (
 	"tkestack.io/galaxy/pkg/ipam/cloudprovider/rpc"
 	"tkestack.io/galaxy/pkg/ipam/floatingip"
 	"tkestack.io/galaxy/pkg/ipam/schedulerplugin/util"
-	tappv1 "tkestack.io/tapp/pkg/apis/tappcontroller/v1"
 )
 
 type resyncObj struct {
@@ -56,18 +53,12 @@ func (p *FloatingIPPlugin) resyncPod() error {
 	if err := p.fetchChecklist(resyncMeta); err != nil {
 		return err
 	}
-	if err := p.fetchAppAndPodMeta(resyncMeta); err != nil {
-		return err
-	}
 	p.resyncAllocatedIPs(resyncMeta)
 	return nil
 }
 
 type resyncMeta struct {
 	allocatedIPs map[string]resyncObj // allocated ips from galaxy pool
-	unfinish     map[string]*corev1.Pod
-	tappMap      map[string]*tappv1.TApp
-	ssMap        map[string]*appv1.StatefulSet
 }
 
 func (p *FloatingIPPlugin) fetchChecklist(meta *resyncMeta) error {
@@ -88,24 +79,11 @@ func (p *FloatingIPPlugin) fetchChecklist(meta *resyncMeta) error {
 			glog.Warningf("unexpected key: %s", fip.Key)
 			continue
 		}
+		if fip.Policy != uint16(constant.ReleasePolicyPodDelete) && fip.NodeName == "" && fip.PodUid == "" {
+			// the ip is already reserved, skip it
+			continue
+		}
 		meta.allocatedIPs[fip.Key] = resyncObj{keyObj: keyObj, fip: fip}
-	}
-	return nil
-}
-
-func (p *FloatingIPPlugin) fetchAppAndPodMeta(meta *resyncMeta) error {
-	var err error
-	meta.unfinish, err = p.listUnfinishPodsToMap()
-	if err != nil {
-		return err
-	}
-	meta.ssMap, err = p.getSSMap()
-	if err != nil {
-		return err
-	}
-	meta.tappMap, err = p.getTAppMap()
-	if err != nil {
-		return err
 	}
 	return nil
 }
@@ -115,93 +93,60 @@ func (p *FloatingIPPlugin) resyncAllocatedIPs(meta *resyncMeta) {
 	for key, obj := range meta.allocatedIPs {
 		func() {
 			defer p.lockPod(obj.keyObj.PodName, obj.keyObj.Namespace)()
-			if _, ok := meta.unfinish[key]; ok {
+			if p.podRunning(obj.keyObj.PodName, obj.keyObj.Namespace, obj.fip.PodUid) {
 				return
 			}
-			// check with apiserver to confirm it really not exist
-			if p.podRunning(obj.keyObj.PodName, obj.keyObj.Namespace) {
-				return
-			}
-			if p.cloudProvider != nil {
-				var attr Attr
-				if err := json.Unmarshal([]byte(obj.fip.Attr), &attr); err != nil {
-					glog.Errorf("failed to unmarshal attr %s for pod %s: %v", obj.fip.Attr, key, err)
+			if p.cloudProvider != nil && obj.fip.NodeName != "" {
+				// For tapp and sts pod, nodeName will be updated to empty after unassigning
+				glog.Infof("UnAssignIP nodeName %s, ip %s, key %s during resync", obj.fip.NodeName,
+					obj.fip.IP.String(), key)
+				if err := p.cloudProviderUnAssignIP(&rpc.UnAssignIPRequest{
+					NodeName:  obj.fip.NodeName,
+					IPAddress: obj.fip.IP.String(),
+				}); err != nil {
+					glog.Warningf("failed to unassign ip %s to %s: %v", obj.fip.IP.String(), key, err)
+					// return to retry unassign ip in the next resync loop
 					return
 				}
-				// For tapp and sts pod, nodeName will be updated to empty after unassigning
-				if attr.NodeName != "" {
-					glog.Infof("UnAssignIP nodeName %s, ip %s, key %s during resync", attr.NodeName,
-						obj.fip.IP.String(), key)
-					if err := p.cloudProviderUnAssignIP(&rpc.UnAssignIPRequest{
-						NodeName:  attr.NodeName,
-						IPAddress: obj.fip.IP.String(),
-					}); err != nil {
-						glog.Warningf("failed to unassign ip %s to %s: %v", obj.fip.IP.String(), key, err)
-						// return to retry unassign ip in the next resync loop
-						return
-					}
-					// for tapp and sts pod, we need to clean its node attr and uid
-					if err := p.ipam.ReserveIP(key, key, getAttr("", "")); err != nil {
-						glog.Errorf("failed to reserve %s ip: %v", key, err)
-					}
+				// for tapp and sts pod, we need to clean its node attr and uid
+				if err := p.reserveIP(key, key, "unassign ip during resync"); err != nil {
+					glog.Error(err)
 				}
 			}
 			releasePolicy := constant.ReleasePolicy(obj.fip.Policy)
-			// we can't get labels of not exist pod, so get them from it's ss or deployment
 			if !obj.keyObj.Deployment() {
-				p.resyncNoneDpPod(meta, obj.keyObj, releasePolicy)
+				if err := p.unbindNoneDpPod(obj.keyObj, releasePolicy, "during resync"); err != nil {
+					glog.Error(err)
+				}
 				return
 			}
-			if err := p.unbindDpPod(obj.keyObj, releasePolicy, "during resyncing"); err != nil {
+			if err := p.unbindDpPod(obj.keyObj, releasePolicy, "during resync"); err != nil {
 				glog.Error(err)
 			}
 		}()
 	}
 }
 
-func (p *FloatingIPPlugin) resyncNoneDpPod(meta *resyncMeta, keyObj *util.KeyObj, releasePolicy constant.ReleasePolicy) {
-	if releasePolicy == constant.ReleasePolicyNever {
-		return
+func (p *FloatingIPPlugin) podRunning(podName, namespace, podUid string) bool {
+	pod, err := p.PodLister.Pods(namespace).Get(podName)
+	if runningAndUidMatch(podUid, pod, err) {
+		return true
 	}
-	var appExist bool
-	var replicas int32
-	appFullName := util.Join(keyObj.AppName, keyObj.Namespace)
-	if keyObj.StatefulSet() {
-		ss, ok := meta.ssMap[appFullName]
-		if ok {
-			appExist = true
-			replicas = 1
-			if ss.Spec.Replicas != nil {
-				replicas = *ss.Spec.Replicas
-			}
-		}
-	} else if keyObj.TApp() {
-		tapp, ok := meta.tappMap[appFullName]
-		if ok {
-			appExist = true
-			replicas = tapp.Spec.Replicas
-		}
-	} else {
-		// release for other apps
-		appExist = false
-	}
-	if should, reason, err := p.shouldRelease(keyObj, releasePolicy, appExist, replicas); err != nil {
-		glog.Warning(err)
-	} else if should {
-		if err := p.releaseIP(keyObj.KeyInDB, fmt.Sprintf("%s during resyncing", reason)); err != nil {
-			glog.Warning(err)
-		}
-	}
+	// double check with apiserver to confirm it is not running
+	pod, err = p.Client.CoreV1().Pods(namespace).Get(podName, v1.GetOptions{})
+	return runningAndUidMatch(podUid, pod, err)
 }
 
-func (p *FloatingIPPlugin) podRunning(podName, namespace string) bool {
-	pod, err := p.Client.CoreV1().Pods(namespace).Get(podName, v1.GetOptions{})
+func runningAndUidMatch(storedUid string, pod *corev1.Pod, err error) bool {
 	if err != nil {
 		if metaErrs.IsNotFound(err) {
 			return false
 		}
 		// we cannot figure out whether pod exist or not, we'd better keep the ip
 		return true
+	}
+	if storedUid != "" && storedUid != string(pod.GetUID()) {
+		return false
 	}
 	return !finished(pod)
 }
@@ -223,25 +168,6 @@ func (p *FloatingIPPlugin) listWantedPods() ([]*corev1.Pod, error) {
 		}
 	}
 	return filtered, nil
-}
-
-func (p *FloatingIPPlugin) listUnfinishPodsToMap() (map[string]*corev1.Pod, error) {
-	pods, err := p.listWantedPods()
-	if err != nil {
-		return nil, err
-	}
-	unfinish := map[string]*corev1.Pod{}
-	for i := range pods {
-		if finished(pods[i]) {
-			continue
-		}
-		keyObj, err := util.FormatKey(pods[i])
-		if err != nil {
-			continue
-		}
-		unfinish[keyObj.KeyInDB] = pods[i]
-	}
-	return unfinish, nil
 }
 
 // syncPodIPs sync all pods' ips with db, if a pod has PodIP and its ip is unallocated, allocate the ip to it
@@ -269,6 +195,7 @@ func (p *FloatingIPPlugin) syncPodIP(pod *corev1.Pod) error {
 	if pod.Annotations == nil {
 		return nil
 	}
+	defer p.lockPod(pod.Name, pod.Namespace)()
 	keyObj, err := util.FormatKey(pod)
 	if err != nil {
 		glog.V(5).Infof("sync pod %s/%s ip formatKey with error %v", pod.Namespace, pod.Name, err)
@@ -296,8 +223,9 @@ func (p *FloatingIPPlugin) syncIP(key string, ip net.IP, pod *corev1.Pod) error 
 			return fmt.Errorf("conflict ip %s found for both %s and %s", ip.String(), key, storedKey)
 		}
 	} else {
-		if err := p.ipam.AllocateSpecificIP(key, ip, parseReleasePolicy(&pod.ObjectMeta),
-			getAttr(pod.Spec.NodeName, string(pod.UID))); err != nil {
+		attr := floatingip.Attr{
+			Policy: parseReleasePolicy(&pod.ObjectMeta), NodeName: pod.Spec.NodeName, Uid: string(pod.UID)}
+		if err := p.ipam.AllocateSpecificIP(key, ip, attr); err != nil {
 			return err
 		}
 		glog.Infof("updated floatingip %s to key %s", ip.String(), key)

--- a/pkg/ipam/schedulerplugin/resync.go
+++ b/pkg/ipam/schedulerplugin/resync.go
@@ -79,10 +79,6 @@ func (p *FloatingIPPlugin) fetchChecklist(meta *resyncMeta) error {
 			glog.Warningf("unexpected key: %s", fip.Key)
 			continue
 		}
-		if fip.Policy != uint16(constant.ReleasePolicyPodDelete) && fip.NodeName == "" && fip.PodUid == "" {
-			// the ip is already reserved, skip it
-			continue
-		}
 		meta.allocatedIPs[fip.Key] = resyncObj{keyObj: keyObj, fip: fip}
 	}
 	return nil

--- a/pkg/ipam/schedulerplugin/tapp.go
+++ b/pkg/ipam/schedulerplugin/tapp.go
@@ -17,37 +17,9 @@
 package schedulerplugin
 
 import (
-	"fmt"
-
 	metaErrs "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
-	glog "k8s.io/klog"
 	"tkestack.io/galaxy/pkg/ipam/schedulerplugin/util"
-	tappv1 "tkestack.io/tapp/pkg/apis/tappcontroller/v1"
 )
-
-func tAppFullName(tapp *tappv1.TApp) string {
-	return fmt.Sprintf("%s_%s", tapp.Namespace, tapp.Name)
-}
-
-func (p *FloatingIPPlugin) getTAppMap() (map[string]*tappv1.TApp, error) {
-	if p.TAppLister == nil {
-		return map[string]*tappv1.TApp{}, nil
-	}
-	tApps, err := p.TAppLister.List(labels.Everything())
-	if err != nil {
-		return nil, err
-	}
-	key2App := make(map[string]*tappv1.TApp)
-	for i := range tApps {
-		if !p.hasResourceName(&tApps[i].Spec.Template.Spec) {
-			continue
-		}
-		key2App[tAppFullName(tApps[i])] = tApps[i]
-	}
-	glog.V(5).Infof("%v", key2App)
-	return key2App, nil
-}
 
 func (p *FloatingIPPlugin) getTAppReplicas(keyObj *util.KeyObj) (appExist bool, replicas int32, retErr error) {
 	tapp, err := p.TAppLister.TApps(keyObj.Namespace).Get(keyObj.AppName)


### PR DESCRIPTION
- Previously, resync does nothing if pod name unchanged because it
checked pod running only by name
- Delete resyncNoneDpPod which is a duplicate func of unbindNoneDpPod
- Ipam instead of floatingip plugin decides how to store attributes.
So later we can update nodeName and podUid to be specific fields of fip crd