### PR TITLE
fix(builder): use arm64/v8 when pushing images to docker hub

### DIFF
--- a/build/lib/create-manifest.sh
+++ b/build/lib/create-manifest.sh
@@ -40,7 +40,7 @@ for platform in ${PLATFORMS}; do
   arch=${platform#*_}
   variant=""
   if [ ${arch} == "arm64" ]; then
-    variant="--variant unknown"
+    variant="--variant v8"
   fi
 
   docker manifest create --amend ${DES_REGISTRY}:${VERSION} \


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug
> /kind design

**What this PR does / why we need it**:
`arm64/unknown` is only for UOS. 

We should use `arm64/v8` when pushing arm64 images to docker hub

**Which issue(s) this PR fixes**:
See tkestack/tke issues for details: https://github.com/tkestack/tke/issues/835
