### PR TITLE
add mtu config in ipvlan and macvlan mode

### DIFF
--- a/cni/k8s-vlan/k8s_vlan.go
+++ b/cni/k8s-vlan/k8s_vlan.go
@@ -105,7 +105,7 @@ func setupMacvlan(result *t020.Result, vlanId uint16, args *skel.CmdArgs) error 
 	if err := d.MaybeCreateVlanDevice(vlanId); err != nil {
 		return err
 	}
-	if err := utils.MacVlanConnectsHostWithContainer(result, args, d.DeviceIndex); err != nil {
+	if err := utils.MacVlanConnectsHostWithContainer(result, args, d.DeviceIndex, d.MTU); err != nil {
 		return err
 	}
 	_ = utils.SendGratuitousARP(args.IfName, result.IP4.IP.IP.String(), args.Netns, d.GratuitousArpRequest)
@@ -117,7 +117,7 @@ func setupIPVlan(result *t020.Result, vlanId uint16, args *skel.CmdArgs) error {
 		return err
 	}
 
-	if err := utils.IPVlanConnectsHostWithContainer(result, args, d.DeviceIndex, d.GetIPVlanMode()); err != nil {
+	if err := utils.IPVlanConnectsHostWithContainer(result, args, d.DeviceIndex, d.GetIPVlanMode(), d.MTU); err != nil {
 		return err
 	}
 

--- a/pkg/network/vlan/vlan.go
+++ b/pkg/network/vlan/vlan.go
@@ -66,6 +66,8 @@ type NetConf struct {
 	VlanNamePrefix string `json:"vlan_name_prefix"`
 
 	GratuitousArpRequest bool `json:"gratuitous_arp_request"`
+
+	MTU int `json:"mtu"`
 }
 
 func (d *VlanDriver) LoadConf(bytes []byte) (*NetConf, error) {
@@ -85,6 +87,7 @@ func (d *VlanDriver) LoadConf(bytes []byte) (*NetConf, error) {
 	if conf.IpVlanMode == "" {
 		conf.IpVlanMode = DefaultIPVlanMode
 	}
+
 	d.NetConf = conf
 	return conf, nil
 }
@@ -94,6 +97,9 @@ func (d *VlanDriver) Init() error {
 	device, err := netlink.LinkByName(d.Device)
 	if err != nil {
 		return fmt.Errorf("Error getting device %s: %v", d.Device, err)
+	}
+	if d.MTU == 0 {
+		d.MTU = device.Attrs().MTU
 	}
 	d.DeviceIndex = device.Attrs().Index
 	d.vlanParentIndex = device.Attrs().Index

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -361,13 +361,13 @@ func SendGratuitousARP(dev, ip, nns string, useArpRequest bool) error {
 }
 
 // MacVlanConnectsHostWithContainer creates macvlan device onto parent and connects container with host
-func MacVlanConnectsHostWithContainer(result *t020.Result, args *skel.CmdArgs, parent int) error {
+func MacVlanConnectsHostWithContainer(result *t020.Result, args *skel.CmdArgs, parent int, mtu int) error {
 	var err error
 	macVlan := &netlink.Macvlan{
 		Mode: netlink.MACVLAN_MODE_BRIDGE,
 		LinkAttrs: netlink.LinkAttrs{
 			Name:        HostMacVlanName(args.ContainerID),
-			MTU:         1500,
+			MTU:         mtu,
 			ParentIndex: parent,
 		}}
 	if err := netlink.LinkAdd(macVlan); err != nil {
@@ -386,13 +386,13 @@ func MacVlanConnectsHostWithContainer(result *t020.Result, args *skel.CmdArgs, p
 }
 
 // IPVlanConnectsHostWithContainer creates ipvlan device onto parent device and connects container with host
-func IPVlanConnectsHostWithContainer(result *t020.Result, args *skel.CmdArgs, parent int, mode netlink.IPVlanMode) error {
+func IPVlanConnectsHostWithContainer(result *t020.Result, args *skel.CmdArgs, parent int, mode netlink.IPVlanMode, mtu int) error {
 	var err error
 	ipVlan := &netlink.IPVlan{
 		Mode: mode,
 		LinkAttrs: netlink.LinkAttrs{
 			Name:        HostMacVlanName(args.ContainerID),
-			MTU:         1500,
+			MTU:         mtu,
 			ParentIndex: parent,
 		}}
 	if err := netlink.LinkAdd(ipVlan); err != nil {


### PR DESCRIPTION
Default mtu value is 1500 in ipvlan and macvlan mode, it can set mtu by using the following configuration:
```
# kubectl -n kube-system edit cm galaxy-etc 
data:
  galaxy.json: |
    {
      "NetworkConf":[
       ......
       {"name":"galaxy-k8s-vlan","type":"galaxy-k8s-vlan", "device":"eth0", "switch":"ipvlan", "ipvlan_mode":"l2", "mtu": 1450},
       ......
```
