### PR TITLE
Fix veth device name conflict when multi network enabled

### DIFF
--- a/cni/k8s-vlan/k8s_vlan.go
+++ b/cni/k8s-vlan/k8s_vlan.go
@@ -139,7 +139,7 @@ func setupVlanDevice(result020s []*t020.Result, vlanIds []uint16, args *skel.Cmd
 		if err != nil {
 			return err
 		}
-		suffix := fmt.Sprintf("-%d", i+1)
+		suffix := fmt.Sprintf("-%s%d", utils.VlanDeviceSuffix, i+1)
 		if i != 0 {
 			ifIndex++
 			args.IfName = fmt.Sprintf("eth%d", ifIndex)

--- a/cni/k8s-vlan/k8s_vlan.go
+++ b/cni/k8s-vlan/k8s_vlan.go
@@ -139,9 +139,8 @@ func setupVlanDevice(result020s []*t020.Result, vlanIds []uint16, args *skel.Cmd
 		if err != nil {
 			return err
 		}
-		suffix := ""
+		suffix := fmt.Sprintf("-%d", i+1)
 		if i != 0 {
-			suffix = fmt.Sprintf("-%d", i+1)
 			ifIndex++
 			args.IfName = fmt.Sprintf("eth%d", ifIndex)
 			if args.IfName == ifName {

--- a/cni/underlay/veth/veth.go
+++ b/cni/underlay/veth/veth.go
@@ -72,9 +72,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 		if masterDevice, err = vlan.SetupVlanInPureMode(device, vlanId); err != nil {
 			return fmt.Errorf("failed setup vlan: %v", err)
 		}
-		suffix := ""
+		suffix := fmt.Sprintf("-%s%d", utils.UnderlayVethDeviceSuffix, i+1)
 		if i != 0 {
-			suffix = fmt.Sprintf("-%d", i+1)
 			ifIndex++
 			args.IfName = fmt.Sprintf("eth%d", ifIndex)
 			if args.IfName == ifName {

--- a/cni/veth/veth.go
+++ b/cni/veth/veth.go
@@ -211,7 +211,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
-	if err := utils.DeleteHostVeth(args.ContainerID); err != nil {
+	if err := utils.DeleteHostVeth(args.ContainerID, ""); err != nil {
 		return err
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -223,11 +223,11 @@ func DeleteAllVeth(netnsPath string) error {
 }
 
 func HostVethName(containerId string, suffix string) string {
-	return fmt.Sprintf("v-h%s%s", containerId[0:8], suffix)
+	return fmt.Sprintf("v-h%s%s", containerId[0:9], suffix)
 }
 
 func ContainerVethName(containerId string, suffix string) string {
-	return fmt.Sprintf("v-s%s%s", containerId[0:8], suffix)
+	return fmt.Sprintf("v-s%s%s", containerId[0:9], suffix)
 }
 
 func HostMacVlanName(containerId string) string {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -34,6 +34,11 @@ import (
 	"tkestack.io/galaxy/pkg/api/cniutil"
 )
 
+const (
+	UnderlayVethDeviceSuffix = "u"
+	VlanDeviceSuffix = "l"
+)
+
 var (
 	ErrNoDefaultRoute = errors.New("no default route was found")
 )
@@ -171,8 +176,8 @@ func DeleteVeth(netnsPath, ifName string) error {
 }
 
 // DeleteHostVeth deletes veth device in the host network namespace
-func DeleteHostVeth(containerId string) error {
-	hostIfName := HostVethName(containerId, "")
+func DeleteHostVeth(containerId, suffix string) error {
+	hostIfName := HostVethName(containerId, suffix)
 	link, err := netlink.LinkByName(hostIfName)
 	if err != nil {
 		// return nil if we can't find host veth device
@@ -218,11 +223,11 @@ func DeleteAllVeth(netnsPath string) error {
 }
 
 func HostVethName(containerId string, suffix string) string {
-	return fmt.Sprintf("v-h%s%s", containerId[0:9], suffix)
+	return fmt.Sprintf("v-h%s%s", containerId[0:8], suffix)
 }
 
 func ContainerVethName(containerId string, suffix string) string {
-	return fmt.Sprintf("v-s%s%s", containerId[0:9], suffix)
+	return fmt.Sprintf("v-s%s%s", containerId[0:8], suffix)
 }
 
 func HostMacVlanName(containerId string) string {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	UnderlayVethDeviceSuffix = "u"
-	VlanDeviceSuffix = "l"
+	VlanDeviceSuffix         = "l"
 )
 
 var (

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -26,7 +26,7 @@ import (
 func TestDeleteHostVeth(t *testing.T) {
 	containerId := "TestDeleteHostVeth"
 	// check delete a not exist veth
-	if err := DeleteHostVeth(containerId); err != nil {
+	if err := DeleteHostVeth(containerId, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -34,7 +34,7 @@ func TestDeleteHostVeth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := DeleteHostVeth(containerId); err != nil {
+	if err := DeleteHostVeth(containerId, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tools/network/setupvlan.go
+++ b/tools/network/setupvlan.go
@@ -79,7 +79,7 @@ func main() {
 					},
 				}},
 			},
-		}, &skel.CmdArgs{Netns: *flagNetns, IfName: "eth0"}, bridgeName, "", nil); err != nil {
+		}, &skel.CmdArgs{Netns: *flagNetns, IfName: "eth0"}, bridgeName, utils.VlanDeviceSuffix, nil); err != nil {
 			glog.Fatalf("Error creating veth %v", err)
 		}
 	}


### PR DESCRIPTION
now, follow cni plugin dependency veth device
- galaxy-underlay-veth
- galaxy-veth
- galaxy-k8s-vlan

when multi network enable for example flannel and k8s-vlan, the veth device name may conflict。

this pull request use different suffix for different cni plugin.