### PR TITLE
Fix veth device name conflict when multi network enabled

### DIFF
--- a/cni/k8s-vlan/k8s_vlan.go
+++ b/cni/k8s-vlan/k8s_vlan.go
@@ -139,9 +139,8 @@ func setupVlanDevice(result020s []*t020.Result, vlanIds []uint16, args *skel.Cmd
 		if err != nil {
 			return err
 		}
-		suffix := ""
+		suffix := fmt.Sprintf("-%s%d", utils.VlanDeviceSuffix, i)
 		if i != 0 {
-			suffix = fmt.Sprintf("-%d", i+1)
 			ifIndex++
 			args.IfName = fmt.Sprintf("eth%d", ifIndex)
 			if args.IfName == ifName {

--- a/cni/underlay/veth/veth.go
+++ b/cni/underlay/veth/veth.go
@@ -72,9 +72,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 		if masterDevice, err = vlan.SetupVlanInPureMode(device, vlanId); err != nil {
 			return fmt.Errorf("failed setup vlan: %v", err)
 		}
-		suffix := ""
+		suffix := fmt.Sprintf("-%s%d", utils.UnderlayVethDeviceSuffix, i)
 		if i != 0 {
-			suffix = fmt.Sprintf("-%d", i+1)
 			ifIndex++
 			args.IfName = fmt.Sprintf("eth%d", ifIndex)
 			if args.IfName == ifName {

--- a/cni/veth/veth.go
+++ b/cni/veth/veth.go
@@ -211,7 +211,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
-	if err := utils.DeleteHostVeth(args.ContainerID); err != nil {
+	if err := utils.DeleteHostVeth(args.ContainerID, ""); err != nil {
 		return err
 	}
 

--- a/e2e/k8s-vlan/bridge_test.go
+++ b/e2e/k8s-vlan/bridge_test.go
@@ -17,6 +17,8 @@
 package k8s_vlan
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"tkestack.io/galaxy/e2e/helper"
@@ -85,7 +87,7 @@ var _ = Describe("galaxy-k8s-vlan bridge and pure test", func() {
 		// check host iface topology, route, neigh, ip address is expected
 		err := (&helper.NetworkTopology{
 			LeaveDevices: []*helper.LinkDevice{
-				helper.NewLinkDevice(nil, utils.HostVethName(containerId, ""), "veth"),
+				helper.NewLinkDevice(nil, utils.HostVethName(containerId, fmt.Sprintf("-%s%d", utils.VlanDeviceSuffix, 0)), "veth"),
 				helper.NewLinkDevice(cidrIPNet, "dummy0", "dummy"),
 			},
 		}).Verify()

--- a/e2e/k8s-vlan/vlan_test.go
+++ b/e2e/k8s-vlan/vlan_test.go
@@ -17,6 +17,7 @@
 package k8s_vlan
 
 import (
+	"fmt"
 	"net"
 
 	. "github.com/onsi/ginkgo"
@@ -33,7 +34,7 @@ var _ = Describe("galaxy-k8s-vlan vlan test", func() {
 	containerCidr := "192.168.0.68/26"
 	containerId := helper.NewContainerId()
 	cidrIPNet, _ := ips.ParseCIDR(ifaceCidr)
-	hostVeth1 := helper.NewLinkDevice(nil, utils.HostVethName(containerId, ""), "veth").SetMaster(
+	hostVeth1 := helper.NewLinkDevice(nil, utils.HostVethName(containerId, fmt.Sprintf("-%s%d", utils.VlanDeviceSuffix, 0)), "veth").SetMaster(
 		helper.NewLinkDevice(nil, "br2", "bridge"),
 	)
 	dummyVlan2 := helper.NewDummyVlan(cidrIPNet, 2)
@@ -89,7 +90,7 @@ var _ = Describe("galaxy-k8s-vlan vlan test", func() {
 			LeaveDevices: []*helper.LinkDevice{
 				hostVeth1,
 				dummyVlan2,
-				helper.NewLinkDevice(nil, utils.HostVethName(containerId, "-2"), "veth").SetMaster(
+				helper.NewLinkDevice(nil, utils.HostVethName(containerId, fmt.Sprintf("-%s%d", utils.VlanDeviceSuffix, 1)), "veth").SetMaster(
 					helper.NewLinkDevice(nil, "br3", "bridge"),
 				),
 				helper.NewDummyVlan(cidrIPNet, 3),

--- a/e2e/underlay/veth/veth_test.go
+++ b/e2e/underlay/veth/veth_test.go
@@ -1,6 +1,8 @@
 package veth
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"tkestack.io/galaxy/e2e/helper"
@@ -36,7 +38,7 @@ var _ = Describe("galaxy-underlay-veth vlan test", func() {
 
 		err = (&helper.NetworkTopology{
 			LeaveDevices: []*helper.LinkDevice{
-				helper.NewLinkDevice(nil, utils.HostVethName(containerId, ""), "veth"),
+				helper.NewLinkDevice(nil, utils.HostVethName(containerId, fmt.Sprintf("-%s%d", utils.UnderlayVethDeviceSuffix, 0)), "veth"),
 			},
 		}).Verify()
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -34,6 +34,11 @@ import (
 	"tkestack.io/galaxy/pkg/api/cniutil"
 )
 
+const (
+	UnderlayVethDeviceSuffix = "u"
+	VlanDeviceSuffix         = "l"
+)
+
 var (
 	ErrNoDefaultRoute = errors.New("no default route was found")
 )
@@ -171,8 +176,8 @@ func DeleteVeth(netnsPath, ifName string) error {
 }
 
 // DeleteHostVeth deletes veth device in the host network namespace
-func DeleteHostVeth(containerId string) error {
-	hostIfName := HostVethName(containerId, "")
+func DeleteHostVeth(containerId, suffix string) error {
+	hostIfName := HostVethName(containerId, suffix)
 	link, err := netlink.LinkByName(hostIfName)
 	if err != nil {
 		// return nil if we can't find host veth device

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -26,7 +26,7 @@ import (
 func TestDeleteHostVeth(t *testing.T) {
 	containerId := "TestDeleteHostVeth"
 	// check delete a not exist veth
-	if err := DeleteHostVeth(containerId); err != nil {
+	if err := DeleteHostVeth(containerId, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -34,7 +34,7 @@ func TestDeleteHostVeth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := DeleteHostVeth(containerId); err != nil {
+	if err := DeleteHostVeth(containerId, ""); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
follow cni plugin dependency veth device

- galaxy-underlay-veth
- galaxy-veth
- galaxy-k8s-vlan
when multi network enable for example flannel and k8s-vlan, the veth device name may conflict。

this patch use different suffix for galaxy-k8s-vlan and galaxy-underlay-veth plugin but keep galaxy-veth device name not changed for backward compatibility.