### PR TITLE
Fix missing network name

### DIFF
--- a/yaml/galaxy.yaml
+++ b/yaml/galaxy.yaml
@@ -183,6 +183,7 @@ metadata:
 data:
   00-galaxy.conf: |
     {
+      "name": "galaxy-sdn",
       "type": "galaxy-sdn",
       "capabilities": {"portMappings": true},
       "cniVersion": "0.2.0"


### PR DESCRIPTION
Fix https://github.com/tkestack/galaxy/issues/123 https://github.com/tkestack/galaxy/issues/124

Since https://github.com/containernetworking/cni/releases/tag/v0.8.0 name field matters, kubernetes upgrade the cni mod in 1.19.0, so galaxy won't work on kubernetes 1.19+

https://github.com/kubernetes/kubernetes/blob/v1.19.0/go.mod#L31
https://github.com/containernetworking/cni/blob/6fc72a49e9ad357698b64634d60e0a83300284bf/pkg/utils/utils.go#L53